### PR TITLE
Create Next.js frontend for ExoGen dashboard

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,35 @@
+:root {
+  color-scheme: dark;
+  background-color: #050b1f;
+  color: #e5e7ff;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(35, 55, 135, 0.45), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(84, 113, 255, 0.4), transparent 35%),
+    #050b1f;
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  width: min(1200px, 92vw);
+  margin: 0 auto 4rem;
+}
+
+section {
+  margin-bottom: 3.5rem;
+}
+
+button {
+  font-family: inherit;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import './globals.css';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'ExoGen | Current Exoplanets',
+  description: 'Explore current exoplanets with ExoGen.'
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -1,0 +1,216 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 28px;
+  min-height: 320px;
+  background: linear-gradient(180deg, rgba(6, 12, 31, 0.65) 0%, rgba(6, 12, 31, 0.9) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.heroImageWrapper {
+  position: absolute;
+  inset: 0;
+}
+
+.heroImageWrapper::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('/images/exoplanet-banner.svg') center/cover no-repeat;
+  opacity: 0.85;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 1;
+  padding: 3rem clamp(1.5rem, 4vw, 3.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 540px;
+}
+
+.heroSubtitle {
+  font-size: 1rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(224, 233, 255, 0.75);
+}
+
+.heroTitle {
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.heroDescription {
+  color: rgba(224, 231, 255, 0.78);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 2rem;
+}
+
+.panel {
+  background: rgba(9, 15, 40, 0.85);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.3);
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panelTitle {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.panelSubtitle {
+  color: rgba(195, 205, 255, 0.7);
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.searchBar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(16, 24, 56, 0.85);
+  border-radius: 12px;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.searchInput {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.searchInput:focus {
+  outline: none;
+}
+
+.planetList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.planetCard {
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(14, 20, 48, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.planetCard:hover {
+  transform: translateY(-2px);
+  border-color: rgba(120, 175, 255, 0.45);
+}
+
+.planetName {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.planetMeta {
+  color: rgba(197, 204, 255, 0.65);
+  font-size: 0.9rem;
+}
+
+.dataPlaceholder {
+  flex: 1;
+  border-radius: 20px;
+  border: 1px dashed rgba(151, 171, 255, 0.4);
+  background: rgba(12, 18, 45, 0.65);
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  color: rgba(193, 209, 255, 0.72);
+  line-height: 1.6;
+}
+
+.placeholderActions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 1.75rem;
+}
+
+.placeholderTag {
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(84, 113, 255, 0.15);
+  border: 1px solid rgba(112, 147, 255, 0.35);
+  font-size: 0.8rem;
+}
+
+.exportBar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.exportButton {
+  background: linear-gradient(90deg, #4d6bff 0%, #7b5dff 100%);
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 12px 32px rgba(90, 110, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.exportButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 36px rgba(90, 110, 255, 0.45);
+}
+
+@media (max-width: 1024px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    padding: 1.75rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .heroContent {
+    padding: 2.25rem 1.5rem;
+  }
+
+  .panel {
+    padding: 1.5rem;
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,127 @@
+import { Header } from '@/components/Header';
+import styles from './page.module.css';
+
+const planetSummaries = [
+  {
+    name: '11 Com B',
+    year: '2007',
+    method: 'Radial Velocity',
+    facility: 'Xinglong Station'
+  },
+  {
+    name: 'Thestia-1',
+    year: '2017',
+    method: 'Transit',
+    facility: 'Placeholder Laboratory'
+  },
+  {
+    name: '14 And b',
+    year: '2008',
+    method: 'Radial Velocity',
+    facility: 'Qianyan Observatory'
+  }
+];
+
+export default function Home() {
+  return (
+    <>
+      <Header />
+      <main className={styles.main}>
+        <section className={styles.hero}>
+          <div className={styles.heroImageWrapper} aria-hidden="true" />
+          <div className={styles.heroContent}>
+            <span className={styles.heroSubtitle}>Current Exoplanets</span>
+            <h1 className={styles.heroTitle}>Exploring new worlds beyond our Solar System</h1>
+            <p className={styles.heroDescription}>
+              Discover catalogued exoplanets, compare discovery methods, and prepare space for
+              future data visualisations powered by your mission APIs.
+            </p>
+          </div>
+        </section>
+
+        <section id="explore" className={styles.dashboard}>
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <div>
+                <h2 className={styles.panelTitle}>Explore the Planets</h2>
+                <p className={styles.panelSubtitle}>
+                  Search and filter upcoming datasets to curate your observation list.
+                </p>
+              </div>
+            </div>
+
+            <div className={styles.searchBar}>
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M11 4a7 7 0 1 1-4.95 11.95l-2.5 2.5"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  opacity="0.7"
+                />
+              </svg>
+              <input
+                className={styles.searchInput}
+                type="search"
+                placeholder="Search exoplanet"
+                aria-label="Search exoplanet"
+                disabled
+              />
+            </div>
+
+            <div className={styles.planetList}>
+              {planetSummaries.map((planet) => (
+                <article key={planet.name} className={styles.planetCard}>
+                  <span className={styles.planetName}>{planet.name}</span>
+                  <span className={styles.planetMeta}>
+                    Discovery Method: {planet.method} · Discovery Year: {planet.year}
+                  </span>
+                  <span className={styles.planetMeta}>Discovery Facility: {planet.facility}</span>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div id="data" className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <div>
+                <h2 className={styles.panelTitle}>Exoplanet data (Visuals)</h2>
+                <p className={styles.panelSubtitle}>
+                  Future graph integrations will render mission telemetry in this canvas.
+                </p>
+              </div>
+            </div>
+            <div className={styles.dataPlaceholder}>
+              <div>
+                <strong>Reserved for interactive visuals</strong>
+                <p>
+                  Connect your analytics service to stream discovery metrics, orbital charts, or
+                  comparative spectra directly into this panel.
+                </p>
+                <div className={styles.placeholderActions}>
+                  <span className={styles.placeholderTag}>API Hook</span>
+                  <span className={styles.placeholderTag}>Telemetry Feed</span>
+                  <span className={styles.placeholderTag}>Render Surface</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="export" className={styles.exportBar}>
+          <button type="button" className={styles.exportButton}>
+            Export Data
+          </button>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/frontend/components/Header.module.css
+++ b/frontend/components/Header.module.css
@@ -1,0 +1,46 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: linear-gradient(
+    90deg,
+    rgba(5, 11, 31, 0.85) 0%,
+    rgba(5, 11, 31, 0.4) 100%
+  );
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.brandName {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #f3f4ff;
+  letter-spacing: 0.04em;
+}
+
+.nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.link {
+  color: rgba(229, 231, 255, 0.8);
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.link:hover {
+  color: #ffffff;
+  transform: translateY(-1px);
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import styles from './Header.module.css';
+
+export function Header() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.brand}>
+        <Image
+          src="/images/exogen-logo.svg"
+          alt="ExoGen logo"
+          width={56}
+          height={56}
+        />
+        <span className={styles.brandName}>ExoGen</span>
+      </div>
+      <nav className={styles.nav}>
+        <a href="#explore" className={styles.link}>
+          Explore
+        </a>
+        <a href="#data" className={styles.link}>
+          Data
+        </a>
+        <a href="#export" className={styles.link}>
+          Export
+        </a>
+      </nav>
+    </header>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**'
+      }
+    ]
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "exogen-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.48",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.4",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/public/images/exogen-logo.svg
+++ b/frontend/public/images/exogen-logo.svg
@@ -1,0 +1,11 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="64" cy="64" r="60" fill="#0D1F45"/>
+  <circle cx="64" cy="64" r="42" fill="#18366D"/>
+  <path d="M28 72c12-20 56-44 80-34" stroke="#7CC4FF" stroke-width="6" stroke-linecap="round"/>
+  <path d="M30 78c12 16 50 34 72 26" stroke="#9AD1FF" stroke-width="5" stroke-linecap="round"/>
+  <text x="64" y="72" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="32" font-weight="700" fill="white">Exo</text>
+  <text x="64" y="98" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" font-weight="500" fill="#A8C5FF">Gen</text>
+  <circle cx="32" cy="38" r="3" fill="white"/>
+  <circle cx="88" cy="28" r="2" fill="#A8C5FF"/>
+  <circle cx="104" cy="70" r="2.5" fill="#A8C5FF"/>
+</svg>

--- a/frontend/public/images/exoplanet-banner.svg
+++ b/frontend/public/images/exoplanet-banner.svg
@@ -1,0 +1,42 @@
+<svg width="1440" height="480" viewBox="0 0 1440 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="480" fill="#050B1F"/>
+  <defs>
+    <radialGradient id="planetGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(720 200) scale(700 260)">
+      <stop offset="0" stop-color="#FFB6A6" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#050B1F" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="ringGradient" x1="0" y1="0" x2="1" y2="0">
+      <stop stop-color="#A8C5FF" stop-opacity="0.05"/>
+      <stop offset="1" stop-color="#4A6BFF" stop-opacity="0.35"/>
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="480" fill="url(#planetGlow)"/>
+  <g opacity="0.25">
+    <circle cx="320" cy="260" r="120" fill="#F98667"/>
+    <circle cx="640" cy="220" r="130" fill="#D87C5F"/>
+    <circle cx="920" cy="240" r="120" fill="#4C6EFF"/>
+    <circle cx="1160" cy="230" r="110" fill="#3B4FE8"/>
+  </g>
+  <g opacity="0.35">
+    <ellipse cx="640" cy="230" rx="200" ry="58" fill="url(#ringGradient)"/>
+    <ellipse cx="320" cy="270" rx="180" ry="48" fill="url(#ringGradient)"/>
+    <ellipse cx="920" cy="250" rx="190" ry="54" fill="url(#ringGradient)"/>
+    <ellipse cx="1160" cy="240" rx="160" ry="45" fill="url(#ringGradient)"/>
+  </g>
+  <g opacity="0.8">
+    <circle cx="320" cy="250" r="100" fill="url(#planetGlow)"/>
+    <circle cx="640" cy="220" r="110" fill="url(#planetGlow)"/>
+    <circle cx="920" cy="240" r="100" fill="url(#planetGlow)"/>
+    <circle cx="1160" cy="230" r="94" fill="url(#planetGlow)"/>
+  </g>
+  <g fill="#FFFFFF" opacity="0.45">
+    <circle cx="240" cy="120" r="2"/>
+    <circle cx="420" cy="80" r="1.5"/>
+    <circle cx="1000" cy="90" r="1.8"/>
+    <circle cx="1180" cy="60" r="1.6"/>
+    <circle cx="900" cy="130" r="1.4"/>
+    <circle cx="680" cy="100" r="1.6"/>
+    <circle cx="540" cy="160" r="1.6"/>
+    <circle cx="780" cy="180" r="1.3"/>
+  </g>
+</svg>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js 14 app that renders the ExoGen hero, exploration panel, and data placeholder views
- create a reusable header component with navigation anchors and global styling
- include SVG artwork assets for the logo and hero banner to mirror the provided mock

## Testing
- not run (npm install blocked by registry 403 errors)


------
https://chatgpt.com/codex/tasks/task_e_68e26e2a71048333a6c681704699ec61