### PR TITLE
Revamp landing layout with monochrome styling

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,8 +1,22 @@
 :root {
   color-scheme: dark;
-  background-color: #050b1f;
-  color: #e5e7ff;
+  background-color: #050505;
+  color: #f5f5f5;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  /*
+    Update the following custom properties with url('path/to/asset') once assets are added to the
+    project repository.
+  */
+  --app-background-image: none;
+  --hero-background-image: none;
+  --brand-logo-image: none;
+  --surface-primary: rgba(12, 12, 12, 0.88);
+  --surface-secondary: rgba(18, 18, 18, 0.78);
+  --surface-tertiary: rgba(28, 28, 28, 0.7);
+  --outline-soft: rgba(255, 255, 255, 0.08);
+  --text-primary: #fafafa;
+  --text-secondary: rgba(255, 255, 255, 0.64);
+  --accent: #ffffff;
 }
 
 * {
@@ -10,11 +24,25 @@
 }
 
 body {
+  position: relative;
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(35, 55, 135, 0.45), transparent 55%),
-    radial-gradient(circle at 20% 20%, rgba(84, 113, 255, 0.4), transparent 35%),
-    #050b1f;
+  color: var(--text-primary);
+  background-color: #050505;
+  background-image: var(--app-background-image);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-attachment: fixed;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.82) 0%, rgba(0, 0, 0, 0.94) 62%, rgba(0, 0, 0, 0.98) 100%);
+  z-index: -1;
 }
 
 a {
@@ -22,7 +50,7 @@ a {
 }
 
 main {
-  width: min(1200px, 92vw);
+  width: min(1180px, 92vw);
   margin: 0 auto 4rem;
 }
 

--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -1,16 +1,17 @@
 .main {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: clamp(2rem, 6vw, 3.5rem);
 }
 
 .hero {
   position: relative;
   overflow: hidden;
-  border-radius: 28px;
-  min-height: 320px;
-  background: linear-gradient(180deg, rgba(6, 12, 31, 0.65) 0%, rgba(6, 12, 31, 0.9) 100%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 32px;
+  min-height: 360px;
+  background: var(--surface-primary);
+  border: 1px solid var(--outline-soft);
+  isolation: isolate;
 }
 
 .heroImageWrapper {
@@ -22,54 +23,67 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: url('/images/exoplanet-banner.svg') center/cover no-repeat;
-  opacity: 0.85;
+  background-image: var(--hero-background-image);
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  filter: grayscale(1);
+  opacity: 0.55;
+}
+
+.heroImageWrapper::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.6) 50%, rgba(0, 0, 0, 0.92) 100%);
 }
 
 .heroContent {
   position: relative;
   z-index: 1;
-  padding: 3rem clamp(1.5rem, 4vw, 3.5rem);
+  padding: clamp(2.5rem, 6vw, 3.5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.35rem;
   max-width: 540px;
 }
 
 .heroSubtitle {
-  font-size: 1rem;
-  letter-spacing: 0.2em;
+  font-size: 0.85rem;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(224, 233, 255, 0.75);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .heroTitle {
-  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  font-size: clamp(2.4rem, 5vw, 3.6rem);
   font-weight: 700;
   line-height: 1.1;
+  color: var(--text-primary);
 }
 
 .heroDescription {
-  color: rgba(224, 231, 255, 0.78);
+  color: var(--text-secondary);
   font-size: 1.05rem;
-  line-height: 1.6;
+  line-height: 1.7;
+  max-width: 480px;
 }
 
 .dashboard {
   display: grid;
   grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
-  gap: 2rem;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .panel {
-  background: rgba(9, 15, 40, 0.85);
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  padding: 2rem;
+  background: var(--surface-secondary);
+  border-radius: 26px;
+  border: 1px solid var(--outline-soft);
+  padding: clamp(1.75rem, 4vw, 2.25rem);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.3);
+  gap: 1.6rem;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
 }
 
 .panelHeader {
@@ -80,24 +94,31 @@
 }
 
 .panelTitle {
-  font-size: 1.6rem;
+  font-size: 1.55rem;
   font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .panelSubtitle {
-  color: rgba(195, 205, 255, 0.7);
+  color: var(--text-secondary);
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
 }
 
 .searchBar {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  background: rgba(16, 24, 56, 0.85);
-  border-radius: 12px;
-  padding: 0.9rem 1.1rem;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  gap: 0.85rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 14px;
+  padding: 0.95rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.searchBar svg {
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .searchInput {
@@ -113,47 +134,74 @@
 }
 
 .planetList {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.85rem;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 0.3rem;
+  margin-right: -0.3rem;
+}
+
+.planetList::-webkit-scrollbar {
+  width: 6px;
+}
+
+.planetList::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 999px;
+}
+
+.planetList::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+}
+
+.planetList {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
 }
 
 .planetCard {
   padding: 1rem 1.25rem;
-  border-radius: 14px;
-  background: rgba(14, 20, 48, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  gap: 0.35rem;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
 .planetCard:hover {
   transform: translateY(-2px);
-  border-color: rgba(120, 175, 255, 0.45);
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .planetName {
   font-weight: 600;
   font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .planetMeta {
-  color: rgba(197, 204, 255, 0.65);
+  color: rgba(255, 255, 255, 0.54);
   font-size: 0.9rem;
 }
 
 .dataPlaceholder {
   flex: 1;
-  border-radius: 20px;
-  border: 1px dashed rgba(151, 171, 255, 0.4);
-  background: rgba(12, 18, 45, 0.65);
+  border-radius: 22px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
   display: grid;
   place-items: center;
-  padding: 3rem 1.5rem;
+  padding: clamp(2.5rem, 5vw, 3.25rem) 1.75rem;
   text-align: center;
-  color: rgba(193, 209, 255, 0.72);
+  color: rgba(255, 255, 255, 0.62);
   line-height: 1.6;
 }
 
@@ -162,15 +210,17 @@
   gap: 0.75rem;
   justify-content: center;
   flex-wrap: wrap;
-  margin-top: 1.75rem;
+  margin-top: 1.85rem;
 }
 
 .placeholderTag {
-  padding: 0.4rem 0.85rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
-  background: rgba(84, 113, 255, 0.15);
-  border: 1px solid rgba(112, 147, 255, 0.35);
-  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .exportBar {
@@ -179,20 +229,23 @@
 }
 
 .exportButton {
-  background: linear-gradient(90deg, #4d6bff 0%, #7b5dff 100%);
-  border: none;
-  color: #fff;
+  background: #f5f5f5;
+  border: 1px solid #f5f5f5;
+  color: #050505;
   font-weight: 600;
   padding: 0.85rem 1.8rem;
   border-radius: 999px;
   cursor: pointer;
-  box-shadow: 0 12px 32px rgba(90, 110, 255, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .exportButton:hover {
   transform: translateY(-1px);
-  box-shadow: 0 14px 36px rgba(90, 110, 255, 0.45);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+  background: #ffffff;
 }
 
 @media (max-width: 1024px) {
@@ -201,7 +254,7 @@
   }
 
   .panel {
-    padding: 1.75rem;
+    padding: clamp(1.5rem, 4vw, 2rem);
   }
 }
 
@@ -211,6 +264,6 @@
   }
 
   .panel {
-    padding: 1.5rem;
+    border-radius: 22px;
   }
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,26 +1,12 @@
 import { Header } from '@/components/Header';
 import styles from './page.module.css';
 
-const planetSummaries = [
-  {
-    name: '11 Com B',
-    year: '2007',
-    method: 'Radial Velocity',
-    facility: 'Xinglong Station'
-  },
-  {
-    name: 'Thestia-1',
-    year: '2017',
-    method: 'Transit',
-    facility: 'Placeholder Laboratory'
-  },
-  {
-    name: '14 And b',
-    year: '2008',
-    method: 'Radial Velocity',
-    facility: 'Qianyan Observatory'
-  }
-];
+const planetSummaries = Array.from({ length: 12 }).map((_, index) => ({
+  name: `Placeholder Planet ${String(index + 1).padStart(2, '0')}`,
+  year: '20XX',
+  method: 'Discovery Method',
+  facility: 'Placeholder Observatory'
+}));
 
 export default function Home() {
   return (
@@ -30,11 +16,12 @@ export default function Home() {
         <section className={styles.hero}>
           <div className={styles.heroImageWrapper} aria-hidden="true" />
           <div className={styles.heroContent}>
-            <span className={styles.heroSubtitle}>Current Exoplanets</span>
+            <span className={styles.heroSubtitle}>Current Catalogue</span>
             <h1 className={styles.heroTitle}>Exploring new worlds beyond our Solar System</h1>
             <p className={styles.heroDescription}>
-              Discover catalogued exoplanets, compare discovery methods, and prepare space for
-              future data visualisations powered by your mission APIs.
+              Browse a curated list of candidate planets, ready to be connected to the mission
+              datasets you will integrate. The monochrome interface keeps attention on the data
+              while leaving space for your future enhancements.
             </p>
           </div>
         </section>
@@ -45,7 +32,7 @@ export default function Home() {
               <div>
                 <h2 className={styles.panelTitle}>Explore the Planets</h2>
                 <p className={styles.panelSubtitle}>
-                  Search and filter upcoming datasets to curate your observation list.
+                  Scroll through the placeholder records and wire up your API when it is ready.
                 </p>
               </div>
             </div>

--- a/frontend/components/Header.module.css
+++ b/frontend/components/Header.module.css
@@ -2,45 +2,79 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem 2rem;
+  padding: 1.35rem clamp(1.5rem, 4vw, 2.75rem);
   position: sticky;
   top: 0;
   z-index: 10;
-  backdrop-filter: blur(12px);
-  background: linear-gradient(
-    90deg,
-    rgba(5, 11, 31, 0.85) 0%,
-    rgba(5, 11, 31, 0.4) 100%
-  );
+  backdrop-filter: blur(14px);
+  background: rgba(12, 12, 12, 0.92);
+  background: color-mix(in srgb, rgba(12, 12, 12, 0.92) 65%, rgba(18, 18, 18, 0.92));
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.9rem;
+}
+
+.brandMark {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background-color: #0a0a0a;
+  background-image: var(--brand-logo-image, linear-gradient(135deg, #ffffff 0%, #161616 100%));
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45);
 }
 
 .brandName {
-  font-size: 1.5rem;
+  font-size: 1.45rem;
   font-weight: 600;
-  color: #f3f4ff;
-  letter-spacing: 0.04em;
+  color: #f5f5f5;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .nav {
   display: flex;
-  gap: 1.5rem;
+  gap: clamp(1rem, 3vw, 2rem);
 }
 
 .link {
-  color: rgba(229, 231, 255, 0.8);
+  color: rgba(235, 235, 235, 0.68);
   font-weight: 500;
   text-decoration: none;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
   transition: color 0.2s ease, transform 0.2s ease;
 }
 
 .link:hover {
   color: #ffffff;
   transform: translateY(-1px);
+}
+
+@media (max-width: 768px) {
+  .header {
+    padding: 1.1rem 1.5rem;
+  }
+
+  .brandMark {
+    width: 44px;
+    height: 44px;
+  }
+
+  .brandName {
+    font-size: 1.25rem;
+    letter-spacing: 0.06em;
+  }
+
+  .nav {
+    gap: 1.25rem;
+  }
 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,19 +1,13 @@
-import Image from 'next/image';
 import styles from './Header.module.css';
 
 export function Header() {
   return (
     <header className={styles.header}>
       <div className={styles.brand}>
-        <Image
-          src="/images/exogen-logo.svg"
-          alt="ExoGen logo"
-          width={56}
-          height={56}
-        />
+        <span className={styles.brandMark} aria-hidden="true" />
         <span className={styles.brandName}>ExoGen</span>
       </div>
-      <nav className={styles.nav}>
+      <nav className={styles.nav} aria-label="Primary">
         <a href="#explore" className={styles.link}>
           Explore
         </a>


### PR DESCRIPTION
## Summary
- restyle the landing hero and panels around a monochrome palette driven by new CSS custom properties
- replace the header logo image with a variable-driven mark so uploaded assets can be referenced later
- expand the placeholder planet list and enable vertical scrolling to match the provided layout guidance

## Testing
- npm install (fails: 403 Forbidden fetching registry packages)

------
https://chatgpt.com/codex/tasks/task_e_68e27fe53fc08333bbb563766231e23b